### PR TITLE
feat: sidemenu 컴포넌트 ui 개발

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,7 +1,11 @@
-export default function DashboarLayout({
-  children,
-}: {
-  children: React.ReactNode
-}) {
-  return <section>{children}</section>
+import SideMenu from '@/components/common/SideMenu/SideMenu'
+
+export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex">
+      <SideMenu />
+      <main className="flex-1">{children}</main>
+    </div>
+  )
 }
+

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,4 +1,4 @@
-import SideMenu from '@/components/common/SideMenu/SideMenu'
+import SideMenu from '@/components/dashboard/SideMenu'
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
   return (

--- a/components/common/Logo.tsx
+++ b/components/common/Logo.tsx
@@ -1,0 +1,12 @@
+import Link from 'next/link'
+import LogoSvg from '@/assets/imgs/img_Logo.svg'
+
+export default function Logo() {
+  return (
+    <div className="px-1 pb-1 border-gray-900">
+      <Link href="/mydashboard">
+        <LogoSvg className="w-40 h-15" />
+      </Link>
+    </div>
+  )
+}

--- a/components/common/SideMenu/SideMenu.tsx
+++ b/components/common/SideMenu/SideMenu.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import Logo from '@/assets/imgs/img_Logo.svg'
+import HashIcon from '@/assets/icons/ic_hash.svg'
+import PlusIcon from '@/assets/icons/ic_plus.svg'
+import SettingIcon from '@/assets/icons/ic_setting.svg'
+
+interface NavItem {
+  label: string
+  href: string
+}
+
+const ITEMS_PER_PAGE = 14
+
+// 대시보드 목록 나중에 불러올거 대비하여 구조 설정, 임시 mock데이터 넣어놨어용
+const NAV_ITEMS: NavItem[] = [
+  { label: '내 대시보드', href: '/mydashboard' },
+  { label: '프로젝트 A', href: '/dashboard/1' },
+  { label: '프로젝트 B', href: '/dashboard/2' },
+  { label: '프로젝트 C', href: '/dashboard/3' },
+  { label: '디자인 시스템', href: '/dashboard/4' },
+  { label: '백엔드 API', href: '/dashboard/5' },
+  { label: '마케팅 플랜', href: '/dashboard/6' },
+  { label: '스프린트 보드', href: '/dashboard/7' },
+  { label: 'QA 체크리스트', href: '/dashboard/8' },
+  { label: '런치 준비', href: '/dashboard/9' },
+  { label: '인프라 설계', href: '/dashboard/10' },
+  { label: 'UI 컴포넌트', href: '/dashboard/11' },
+  { label: '사용자 리서치', href: '/dashboard/12' },
+  { label: '회고 보드', href: '/dashboard/13' },
+  { label: '로드맵 2025', href: '/dashboard/14' },
+  { label: '팀 온보딩', href: '/dashboard/15' },
+  { label: '버그 트래커', href: '/dashboard/16' },
+  { label: '릴리즈 노트', href: '/dashboard/17' },
+]
+
+export default function SideMenu() {
+  const [page, setPage] = useState(1)
+  const totalPages = Math.ceil(NAV_ITEMS.length / ITEMS_PER_PAGE)
+  const pagedItems = NAV_ITEMS.slice((page - 1) * ITEMS_PER_PAGE, page * ITEMS_PER_PAGE)
+
+  return (
+    <aside className="flex flex-col w-[300px] min-h-screen border-r border-gray-900 bg-black-500 py-2">
+      {/* 로고 부분 */}
+      <div className="px-1 pb-1 border-gray-900">
+        <Link href="/mydashboard">
+          <Logo className="w-40 h-15" />
+        </Link>
+      </div>
+
+      {/* 대시보드 목록 헤더 (대시보드 추가 +) */}
+      <div className="flex items-center justify-between px-6 pb-1">
+        <span className="text-sm-13-semibold text-gray-400">
+          대시보드 추가
+        </span>
+        <button
+          type="button"
+          aria-label="대시보드 추가"
+          className="flex items-center justify-center text-gray-400 hover:text-gray-100 bg-transparent border-none cursor-pointer"
+        >
+          <PlusIcon className="w-5 h-5 text-gray-400" />
+        </button>
+      </div>
+
+      {/* 네비게이션 */}
+      <nav className="flex-1 mt-1">
+        <ul className="list-none m-0 p-0">
+          {pagedItems.map((item, index) => (
+            <li key={index} className="mb-1">
+              <Link
+                href={item.href}
+                className="flex items-center gap-2 px-6 py-2.5 text-md-14-medium text-gray-100 no-underline hover:bg-black-300 hover:text-gray-100"
+              >
+                <HashIcon className="w-5 h-5 shrink-0" />
+                {item.label}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      {/* 페이지네이션 */}
+      <div className="flex items-center justify-between px-6 py-4 text-xs-12-medium text-gray-400">
+        <button
+          type="button"
+          onClick={() => setPage((p) => Math.max(1, p - 1))}
+          disabled={page === 1}
+          className="bg-transparent border-none cursor-pointer text-gray-400 hover:text-gray-100 disabled:opacity-30 disabled:cursor-not-allowed"
+        >
+          &lt; 이전
+        </button>
+        <button
+          type="button"
+          onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+          disabled={page === totalPages}
+          className="bg-transparent border-none cursor-pointer text-gray-400 hover:text-gray-100 disabled:opacity-30 disabled:cursor-not-allowed"
+        >
+          다음 &gt;
+        </button>
+      </div>
+
+      {/* 하단 프로필 */}
+      <div className="border-t border-gray-900 px-5 py-4 flex items-center gap-3">
+        {/* 임시 프로필 이미지 */}
+        <div className="w-8 h-8 rounded-full bg-gray-700 shrink-0" />
+        <span className="flex-1 text-md-14-medium text-gray-100">
+          프로필 이름
+        </span>
+        {/* 설정 아이콘 */}
+        <button
+          type="button"
+          aria-label="설정"
+          className="flex items-center justify-center text-gray-400 hover:text-gray-100 bg-transparent border-none cursor-pointer shrink-0"
+        >
+          <SettingIcon className="w-5 h-5" />
+        </button>
+      </div>
+    </aside>
+  )
+}

--- a/components/dashboard/DashboardList.tsx
+++ b/components/dashboard/DashboardList.tsx
@@ -2,10 +2,7 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
-import Logo from '@/assets/imgs/img_Logo.svg'
 import HashIcon from '@/assets/icons/ic_hash.svg'
-import PlusIcon from '@/assets/icons/ic_plus.svg'
-import SettingIcon from '@/assets/icons/ic_setting.svg'
 
 interface NavItem {
   label: string
@@ -36,34 +33,13 @@ const NAV_ITEMS: NavItem[] = [
   { label: '릴리즈 노트', href: '/dashboard/17' },
 ]
 
-export default function SideMenu() {
+export default function DashboardList() {
   const [page, setPage] = useState(1)
   const totalPages = Math.ceil(NAV_ITEMS.length / ITEMS_PER_PAGE)
   const pagedItems = NAV_ITEMS.slice((page - 1) * ITEMS_PER_PAGE, page * ITEMS_PER_PAGE)
 
   return (
-    <aside className="flex flex-col w-[300px] min-h-screen border-r border-gray-900 bg-black-500 py-2">
-      {/* 로고 부분 */}
-      <div className="px-1 pb-1 border-gray-900">
-        <Link href="/mydashboard">
-          <Logo className="w-40 h-15" />
-        </Link>
-      </div>
-
-      {/* 대시보드 목록 헤더 (대시보드 추가 +) */}
-      <div className="flex items-center justify-between px-6 pb-1">
-        <span className="text-sm-13-semibold text-gray-400">
-          대시보드 추가
-        </span>
-        <button
-          type="button"
-          aria-label="대시보드 추가"
-          className="flex items-center justify-center text-gray-400 hover:text-gray-100 bg-transparent border-none cursor-pointer"
-        >
-          <PlusIcon className="w-5 h-5 text-gray-400" />
-        </button>
-      </div>
-
+    <>
       {/* 네비게이션 */}
       <nav className="flex-1 mt-1">
         <ul className="list-none m-0 p-0">
@@ -100,23 +76,6 @@ export default function SideMenu() {
           다음 &gt;
         </button>
       </div>
-
-      {/* 하단 프로필 */}
-      <div className="border-t border-gray-900 px-5 py-4 flex items-center gap-3">
-        {/* 임시 프로필 이미지 */}
-        <div className="w-8 h-8 rounded-full bg-gray-700 shrink-0" />
-        <span className="flex-1 text-md-14-medium text-gray-100">
-          프로필 이름
-        </span>
-        {/* 설정 아이콘 */}
-        <button
-          type="button"
-          aria-label="설정"
-          className="flex items-center justify-center text-gray-400 hover:text-gray-100 bg-transparent border-none cursor-pointer shrink-0"
-        >
-          <SettingIcon className="w-5 h-5" />
-        </button>
-      </div>
-    </aside>
+    </>
   )
 }

--- a/components/dashboard/DashboardSelector.tsx
+++ b/components/dashboard/DashboardSelector.tsx
@@ -1,0 +1,18 @@
+import PlusIcon from '@/assets/icons/ic_plus.svg'
+
+export default function DashboardSelector() {
+  return (
+    <div className="flex items-center justify-between px-6 pb-1">
+      <span className="text-sm-13-semibold text-gray-400">
+        대시보드 추가
+      </span>
+      <button
+        type="button"
+        aria-label="대시보드 추가"
+        className="flex items-center justify-center text-gray-400 hover:text-gray-100 bg-transparent border-none cursor-pointer"
+      >
+        <PlusIcon className="w-5 h-5 text-gray-400" />
+      </button>
+    </div>
+  )
+}

--- a/components/dashboard/SideMenu.tsx
+++ b/components/dashboard/SideMenu.tsx
@@ -1,0 +1,17 @@
+import Logo from '@/components/common/Logo'
+import DashboardSelector from '@/components/dashboard/DashboardSelector'
+import DashboardList from '@/components/dashboard/DashboardList'
+import ProfileImageSection from '@/components/profile/ProfileImageSection'
+
+export default function SideMenu() {
+  return (
+    <aside className="flex flex-col w-[300px] min-h-screen border-r border-gray-900 bg-black-500 py-2">
+      <Logo />
+      <DashboardSelector />
+      <DashboardList />
+      <div className="mt-auto">
+        <ProfileImageSection />
+      </div>
+    </aside>
+  )
+}

--- a/components/profile/ProfileImageSection.tsx
+++ b/components/profile/ProfileImageSection.tsx
@@ -1,0 +1,21 @@
+import SettingIcon from '@/assets/icons/ic_setting.svg'
+
+export default function ProfileImageSection() {
+  return (
+    <div className="border-t border-gray-900 px-5 py-4 flex items-center gap-3">
+      {/* 임시 프로필 이미지 */}
+      <div className="w-8 h-8 rounded-full bg-gray-700 shrink-0" />
+      <span className="flex-1 text-md-14-medium text-gray-100">
+        프로필 이름
+      </span>
+      {/* 설정 아이콘 */}
+      <button
+        type="button"
+        aria-label="설정"
+        className="flex items-center justify-center text-gray-400 hover:text-gray-100 bg-transparent border-none cursor-pointer shrink-0"
+      >
+        <SettingIcon className="w-5 h-5" />
+      </button>
+    </div>
+  )
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,20 @@ const nextConfig: NextConfig = {
             loader: "@svgr/webpack",
             options: {
               icon: true,
+              svgo: true,
+              svgoConfig: {
+                plugins: [
+                  {
+                    name: "removeAttrs",
+                    params: {
+                      attrs: "(fill|stroke)",
+                    },
+                  },
+                ],
+              },
+              svgProps: {
+                fill: "currentColor",
+              },
             },
           },
         ],


### PR DESCRIPTION
### 📝작업 내용

#16 


SideMenu 컴포넌트 UI를 제작했습니다.

- 사이드메뉴 ui
- 사이드메뉴 페이지네이션
- 컴포넌트 분리작업 

### 컴포넌트 분리작업에 대한 간략한 설명

components/common/Logo.tsx - 최상단 회사/서비스 로고
components/dashboard/DashboardSelector.tsx - '대시보드 추가' 헤더와 십자(+) 버튼
components/dashboard/DashboardList.tsx - 대시보드 네비게이션 리스트와 페이지네이션
components/profile/ProfileImageSection.tsx - 하단의 프로필 이미지/이름/설정 영역
그리고 components/dashboard/SideMenu.tsx는 위 4개의 컴포넌트를 조립해서 쓰는 최상단 SideMenu UI




### 기타
하단에 프로필 사진은 임시로 제작해두었고
상단의 로고부분은 svgr이슈가 있어 검정색 상태로 되어있습니다.

### 스크린샷 (선택)

<img width="676" height="917" alt="image" src="https://github.com/user-attachments/assets/8ede2c2e-aeb5-40a8-a4a5-d8361325806f" />

