### PR TITLE
Feat: 공통 모달 컴포넌트 레이아웃, 로그인 페이지 기능 (로그인 성공 시 리디렉트, 실패 시 모달)

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import LogoImg from '@/assets/imgs/img_Logo.svg'
 import AuthLayout from '@/components/auth/AuthLayout'
 import LoginForm from '@/components/auth/LoginForm'
 import LoginLink from '@/components/auth/LoginForm/LoginLink'
@@ -8,7 +9,9 @@ export default function LoginPage() {
     <AuthLayout>
       <div className="mx-auto max-w-130 pt-50">
         <div className="mb-7.5 text-center text-white">
-          <Link href="/">로고</Link>
+          <Link href="/" className="inline-block w-fit">
+            <LogoImg className="mx-auto h-19.25 w-75 md:h-21.75 md:w-85" />
+          </Link>
         </div>
         <LoginForm />
         <LoginLink />

--- a/components/auth/AuthModal/index.tsx
+++ b/components/auth/AuthModal/index.tsx
@@ -1,0 +1,22 @@
+import { LoginState } from '@/libs/types/Auth'
+import Button from '@/components/common/button'
+import ModalLayout from '@/components/common/modal/ModalLayout'
+
+interface AuthModalProps {
+  state: LoginState
+  onClick: () => void
+}
+
+export default function AuthModal({ state, onClick }: AuthModalProps) {
+  return (
+    <ModalLayout
+      className="space-y-8 px-7.5 py-7.5 md:w-114.5 md:px-12.5 md:pt-12.5 md:pb-7.5"
+      onClose={onClick}
+    >
+      <p className="text-lg-16-semibold">{state.message}</p>
+      <Button onClick={onClick} className="w-full">
+        확인
+      </Button>
+    </ModalLayout>
+  )
+}

--- a/components/auth/LoginForm/index.tsx
+++ b/components/auth/LoginForm/index.tsx
@@ -1,10 +1,19 @@
 'use client'
 
-import Input from '@/components/common/input'
-import Button from '@/components/common/button'
-import useLoginForm from '@/hooks/useLoginForm'
+import { useActionState, useState } from 'react'
+import { login } from '@/libs/api/auth'
 import OpenEyeIcon from '@/assets/icons/ic_visibility_on.svg'
 import CloseEyeIcon from '@/assets/icons/ic_visibility_off.svg'
+import useLoginForm from '@/hooks/useLoginForm'
+import { LoginState } from '@/libs/types/Auth'
+import Input from '@/components/common/input'
+import Button from '@/components/common/button'
+import AuthModal from '../AuthModal'
+
+const initialState: LoginState = {
+  success: true,
+  message: '',
+}
 
 export default function LoginForm() {
   const {
@@ -23,8 +32,17 @@ export default function LoginForm() {
 
   const PasswordIcon = isPasswordVisible ? OpenEyeIcon : CloseEyeIcon
 
+  const [state, formAction, isPending] = useActionState(login, initialState)
+  const [dismissedState, setDismissedState] = useState<LoginState | null>(null)
+  const shouldShowErrorModal =
+    !!state?.message && !state.success && state !== dismissedState
+
+  const handleModalClose = () => {
+    setDismissedState(state)
+  }
+
   return (
-    <form action="" className="text-white" onSubmit={(e) => e.preventDefault()}>
+    <form action={formAction} className="text-white">
       <div className="mb-7.5 flex w-full flex-col gap-3">
         <label htmlFor="email">이메일</label>
         <Input
@@ -66,7 +84,6 @@ export default function LoginForm() {
           <button
             type="button"
             onClick={togglePasswordVisibility}
-            aria-label={isPasswordVisible ? '비밀번호 숨기기' : '비밀번호 보기'}
             className="flex items-center"
           >
             <PasswordIcon className="size-6" />
@@ -75,10 +92,14 @@ export default function LoginForm() {
       </div>
 
       <div>
-        <Button className="w-full" disabled={!isFormValid}>
+        <Button className="w-full" disabled={!isFormValid || isPending}>
           로그인
         </Button>
       </div>
+
+      {shouldShowErrorModal && (
+        <AuthModal state={state} onClick={handleModalClose} />
+      )}
     </form>
   )
 }

--- a/components/common/modal/ModalLayout.tsx
+++ b/components/common/modal/ModalLayout.tsx
@@ -1,0 +1,45 @@
+import { ReactNode, useEffect } from 'react'
+
+const BASE_STYLE = 'bg-modal border-stroke rounded-3xl border text-center'
+
+interface ModalLayoutProps {
+  children: ReactNode
+  className?: string
+  onClose?: () => void
+}
+
+export default function ModalLayout({
+  children,
+  className,
+  onClose,
+}: ModalLayoutProps) {
+  useEffect(() => {
+    if (!onClose) return
+
+    const handleEscapeKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose()
+      }
+    }
+
+    window.addEventListener('keydown', handleEscapeKey)
+
+    return () => {
+      window.removeEventListener('keydown', handleEscapeKey)
+    }
+  }, [onClose])
+
+  return (
+    <div
+      className="fixed inset-0 z-70 flex items-center justify-center bg-black/50"
+      onClick={onClose}
+    >
+      <div
+        className={`${BASE_STYLE} ${className ?? ''}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/libs/api/auth.ts
+++ b/libs/api/auth.ts
@@ -1,0 +1,29 @@
+'use server'
+
+import { redirect } from 'next/navigation'
+import { LoginState } from '../types/Auth'
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL
+
+export const login = async (
+  _prevState: LoginState,
+  formData: FormData,
+): Promise<LoginState> => {
+  const email = String(formData.get('email'))
+  const password = String(formData.get('password'))
+
+  const response = await fetch(`${BASE_URL}/auth/login`, {
+    method: 'POST',
+    body: JSON.stringify({ email, password }),
+    headers: { 'Content-Type': 'application/json' },
+  })
+
+  if (!response.ok) {
+    return {
+      success: false,
+      message: '이메일 또는 비밀번호가 일치하지 않습니다.',
+    }
+  }
+
+  redirect('/mydashboard')
+}

--- a/libs/types/Auth.ts
+++ b/libs/types/Auth.ts
@@ -1,0 +1,4 @@
+export interface LoginState {
+  success: boolean
+  message?: string
+}


### PR DESCRIPTION
### 📝작업 내용
#41 

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

auth/login api연결
로그인 성공 시 /mydashoboard로 이동
로그인 실패 시 모달
모달 만들면서 모달 공통으로 해당되는 배경색, 테두리, 바깥 클릭 시 닫기(esc도 가능) 기능이 들어있는
ModalLayout 컴포넌트도 추가로 만들어봤어요.

### 💬리뷰 요구사항(선택)

```js
    <ModalLayout
      className="space-y-8 px-7.5 py-7.5 md:w-114.5 md:px-12.5 md:pt-12.5 md:pb-7.5"
      onClose={onClick}
    >
      <p className="text-lg-16-semibold">{state.message}</p>
      <Button onClick={onClick} className="w-full">
        확인
      </Button>
    </ModalLayout>
```
props로 className과 onClose가 들어있습니다.
