### PR TITLE
feat: 라우팅 가드 추가

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+const PRIVATE_ROUTES = ['/dashboard', '/mydashboard']
+const AUTH_ROUTES = ['/login', '/signup']
+
+export function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl
+  const token = request.cookies.get('accessToken')?.value
+
+  const isPrivateRoute = PRIVATE_ROUTES.some((route) =>
+    pathname.startsWith(route),
+  )
+  const isAuthRoute = AUTH_ROUTES.includes(pathname)
+
+  if (isPrivateRoute && !token) {
+    return NextResponse.redirect(new URL('/login', request.url))
+  }
+
+  if (isAuthRoute && token) {
+    return NextResponse.redirect(new URL('/mydashboard', request.url))
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/dashboard/:path*', '/mydashboard/:path*', '/login', '/signup'],
+}


### PR DESCRIPTION
### 📝작업 내용
#51 

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

accessToken 소지 시 /, /login, /signup 페이지 접근 시 /mydashboard 페이지로 이동
accessToken 미소지 시 /mydashboard, /dashboard/:* 페이지 접근 시 /login 페이지로 이동

참고: https://nextjs.org/docs/app/getting-started/proxy