### PR TITLE
feat: 대시보드 편집 api 4개

### DIFF
--- a/components/dashboard/edit/DashboardEditClient.tsx
+++ b/components/dashboard/edit/DashboardEditClient.tsx
@@ -1,4 +1,4 @@
-'use client';
+'use client'
 
 import {
   DashboardColor,
@@ -6,111 +6,133 @@ import {
   initialMembers,
   Invitation,
   Member,
-} from "./mock";
-import { useMemo, useState } from "react";
-import DashboardSidebar from "./DashboardSidebar";
-import DashboardEditSection from "./DashboardEditSection";
-import MemberManagementSection from "./MemberManagementSection";
-import InviteMemberModal from "./InviteMemberModal";
-import { useRouter } from "next/navigation";
-import Menu from '@/assets/icons/ic_sidemenu.svg';
-import DeleteConfirmModal from "../deleteConfirmModal";
+} from './mock'
+import { useMemo, useState } from 'react'
+import DashboardSidebar from './DashboardSidebar'
+import DashboardEditSection from './DashboardEditSection'
+import MemberManagementSection from './MemberManagementSection'
+import InviteMemberModal from './InviteMemberModal'
+import { useRouter } from 'next/navigation'
+import Menu from '@/assets/icons/ic_sidemenu.svg'
+import DeleteConfirmModal from '../deleteConfirmModal'
+import { updateDashboard } from '@/libs/api/dashboard/updateDashboard'
 
 interface DashboardEditClientProps {
-  dashboardId: string;
+  dashboardId: string
 }
 
-const MEMBER_PAGE_SIZE = 5;
-const INVITE_PAGE_SIZE = 5;
+const MEMBER_PAGE_SIZE = 5
+const INVITE_PAGE_SIZE = 5
 
 export default function DashboardEditClient({
   dashboardId,
 }: DashboardEditClientProps) {
-  const router = useRouter();
+  const router = useRouter()
 
-  const [selectedTab, setSelectedTab] = useState<"edit" | "members">("edit");
-  const [dashboardTitle, setDashboardTitle] = useState("계란말이 만들기");
-  const [selectedColor, setSelectedColor] = useState<DashboardColor>("red");
+  const [selectedTab, setSelectedTab] = useState<'edit' | 'members'>('edit')
+  const [dashboardTitle, setDashboardTitle] = useState('계란말이 만들기')
+  const [selectedColor, setSelectedColor] = useState<DashboardColor>('red')
 
-  const [members, setMembers] = useState<Member[]>(initialMembers);
-  const [invitations, setInvitations] = useState<Invitation[]>(initialInvitations);
+  const [members, setMembers] = useState<Member[]>(initialMembers)
+  const [invitations, setInvitations] =
+    useState<Invitation[]>(initialInvitations)
 
-  const [memberPage, setMemberPage] = useState(1);
-  const [invitePage, setInvitePage] = useState(1);
-  const [isInviteModalOpen, setIsInviteModalOpen] = useState(false);
-  const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
-  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [memberPage, setMemberPage] = useState(1)
+  const [invitePage, setInvitePage] = useState(1)
+  const [isInviteModalOpen, setIsInviteModalOpen] = useState(false)
+  const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false)
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
 
-  const memberTotalPages = Math.max(1, Math.ceil(members.length / MEMBER_PAGE_SIZE));
-  const inviteTotalPages = Math.max(1, Math.ceil(invitations.length / INVITE_PAGE_SIZE));
+  const memberTotalPages = Math.max(
+    1,
+    Math.ceil(members.length / MEMBER_PAGE_SIZE),
+  )
+  const inviteTotalPages = Math.max(
+    1,
+    Math.ceil(invitations.length / INVITE_PAGE_SIZE),
+  )
 
   const pagedMembers = useMemo(() => {
-    const start = (memberPage - 1) * MEMBER_PAGE_SIZE;
-    return members.slice(start, start + MEMBER_PAGE_SIZE);
-  }, [members, memberPage]);
+    const start = (memberPage - 1) * MEMBER_PAGE_SIZE
+    return members.slice(start, start + MEMBER_PAGE_SIZE)
+  }, [members, memberPage])
 
   const pagedInvitations = useMemo(() => {
-    const start = (invitePage - 1) * INVITE_PAGE_SIZE;
-    return invitations.slice(start, start + INVITE_PAGE_SIZE);
-  }, [invitations, invitePage]);
+    const start = (invitePage - 1) * INVITE_PAGE_SIZE
+    return invitations.slice(start, start + INVITE_PAGE_SIZE)
+  }, [invitations, invitePage])
 
-  const handleUpdateDashboard = () => {
-    console.log("dashboard update", {
-      dashboardId,
-      dashboardTitle,
-      selectedColor,
-    });
-    alert("API 연결 전. 로컬 상태만 변경됨");
-  };
+  const handleUpdateDashboard = async () => {
+    const formData = new FormData()
+    formData.append('title', dashboardTitle)
+    formData.append('color', selectedColor)
+
+    try {
+      const res = await updateDashboard(Number(dashboardId), formData)
+
+      if (!res.success) {
+        alert(res.error)
+        return
+      }
+
+      alert('대시보드가 성공적으로 수정되었습니다.')
+    } catch (error) {
+      console.error('Dashboard update error:', error)
+      alert('알 수 없는 오류가 발생했습니다.')
+    }
+  }
 
   const handleDeleteDashboard = () => {
-    setIsDeleteModalOpen(true);
-  };
+    setIsDeleteModalOpen(true)
+  }
 
   const handleConfirmDeleteDashboard = () => {
-    console.log('delete dashboard', dashboardId);
-    setIsDeleteModalOpen(false);
+    console.log('delete dashboard', dashboardId)
+    setIsDeleteModalOpen(false)
   }
 
   const handleDeleteMember = (memberId: number) => {
     setMembers((prev) => {
-      const next = prev.filter((member) => member.id !== memberId);
-      const nextTotalPages = Math.max(1, Math.ceil(next.length / MEMBER_PAGE_SIZE));
-      if (memberPage > nextTotalPages) setMemberPage(nextTotalPages);
-      return next;
-    });
-  };
+      const next = prev.filter((member) => member.id !== memberId)
+      const nextTotalPages = Math.max(
+        1,
+        Math.ceil(next.length / MEMBER_PAGE_SIZE),
+      )
+      if (memberPage > nextTotalPages) setMemberPage(nextTotalPages)
+      return next
+    })
+  }
 
   const handleCancelInvite = (inviteId: number) => {
     setInvitations((prev) => {
-      const next = prev.filter((invite) => invite.id !== inviteId);
-      const nextTotalPages = Math.max(1, Math.ceil(next.length / INVITE_PAGE_SIZE));
-      if (invitePage > nextTotalPages) setInvitePage(nextTotalPages);
-      return next;
-    });
-  };
+      const next = prev.filter((invite) => invite.id !== inviteId)
+      const nextTotalPages = Math.max(
+        1,
+        Math.ceil(next.length / INVITE_PAGE_SIZE),
+      )
+      if (invitePage > nextTotalPages) setInvitePage(nextTotalPages)
+      return next
+    })
+  }
 
   const handleAddInvite = (email: string) => {
-    setInvitations((prev) => [
-      { id: Date.now(), email },
-      ...prev,
-    ]);
-    setInvitePage(1);
-  };
+    setInvitations((prev) => [{ id: Date.now(), email }, ...prev])
+    setInvitePage(1)
+  }
 
   const handleBack = () => {
-    router.push(`/dashboard/${dashboardId}`);
-  };
+    router.push(`/dashboard/${dashboardId}`)
+  }
 
-  const handleChangeTab = (tab: "edit" | "members") => {
-    setSelectedTab(tab);
-    setIsMobileSidebarOpen(false);
+  const handleChangeTab = (tab: 'edit' | 'members') => {
+    setSelectedTab(tab)
+    setIsMobileSidebarOpen(false)
   }
 
   return (
     <>
-      <div className="min-h-screen bg-modal text-white">
-        <div className="flex min-h-screen w-full lg:min-w-[1280px] flex-col md:flex-row">
+      <div className="bg-modal min-h-screen text-white">
+        <div className="flex min-h-screen w-full flex-col md:flex-row lg:min-w-[1280px]">
           <div className="hidden md:block">
             <DashboardSidebar
               selectedTab={selectedTab}
@@ -120,8 +142,8 @@ export default function DashboardEditClient({
           </div>
 
           <div
-            className={`fixed left-0 top-0 z-50 h-screen w-[70vw] max-w-[320px] transition-transform duration-300 md:hidden ${
-              isMobileSidebarOpen ? "translate-x-0" : "-translate-x-full"
+            className={`fixed top-0 left-0 z-50 h-screen w-[70vw] max-w-[320px] transition-transform duration-300 md:hidden ${
+              isMobileSidebarOpen ? 'translate-x-0' : '-translate-x-full'
             }`}
           >
             <DashboardSidebar
@@ -135,23 +157,23 @@ export default function DashboardEditClient({
             <button
               type="button"
               onClick={() => setIsMobileSidebarOpen(false)}
-              className="fixed right-0 top-0 z-40 h-screen w-[100vw] bg-black/70 md:hidden"
+              className="fixed top-0 right-0 z-40 h-screen w-screen bg-black/70 md:hidden"
             />
           )}
 
-          <main className="w-full flex-1 bg-modal min-h-screen">
-            <header className="w-full flex items-center justify-between border-b border-white/5 lg:h-18 md:h-15 h-[50px] lg:px-[30px] md:px-6 pl-[10px] pr-5">
+          <main className="bg-modal min-h-screen w-full flex-1">
+            <header className="flex h-[50px] w-full items-center justify-between border-b border-white/5 pr-5 pl-[10px] md:h-15 md:px-6 lg:h-18 lg:px-[30px]">
               <button
                 type="button"
                 onClick={() => setIsMobileSidebarOpen(true)}
                 className="flex items-center justify-center"
                 aria-label="사이드바 열기"
               >
-                <Menu className="md:hidden size-5" />
+                <Menu className="size-5 md:hidden" />
               </button>
             </header>
 
-            {selectedTab === "edit" ? (
+            {selectedTab === 'edit' ? (
               <DashboardEditSection
                 title={dashboardTitle}
                 selectedColor={selectedColor}
@@ -168,11 +190,15 @@ export default function DashboardEditClient({
                 invitePage={invitePage}
                 memberTotalPages={memberTotalPages}
                 inviteTotalPages={inviteTotalPages}
-                onPrevMemberPage={() => setMemberPage((prev) => Math.max(1, prev - 1))}
+                onPrevMemberPage={() =>
+                  setMemberPage((prev) => Math.max(1, prev - 1))
+                }
                 onNextMemberPage={() =>
                   setMemberPage((prev) => Math.min(memberTotalPages, prev + 1))
                 }
-                onPrevInvitePage={() => setInvitePage((prev) => Math.max(1, prev - 1))}
+                onPrevInvitePage={() =>
+                  setInvitePage((prev) => Math.max(1, prev - 1))
+                }
                 onNextInvitePage={() =>
                   setInvitePage((prev) => Math.min(inviteTotalPages, prev + 1))
                 }

--- a/libs/api/dashboard/deleteDashboardMember.ts
+++ b/libs/api/dashboard/deleteDashboardMember.ts
@@ -1,0 +1,54 @@
+'use server'
+
+import { cookies } from 'next/headers'
+import { ApiResult } from '@/libs/types/Api'
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL
+
+export const deleteMember = async (
+  memberId: number,
+): Promise<ApiResult<null>> => {
+  try {
+    const cookieStore = await cookies()
+    const token = cookieStore.get('accessToken')?.value
+
+    const response = await fetch(`${BASE_URL}/members/${memberId}`, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    })
+
+    if (response.status === 204) {
+      return {
+        success: true,
+        data: null,
+        error: null,
+      }
+    }
+
+    const result = await response.json()
+
+    if (!response.ok) {
+      return {
+        success: false,
+        data: null,
+        error: result.message || '멤버 삭제에 실패했습니다.',
+      }
+    }
+
+    return {
+      success: true,
+      data: null,
+      error: null,
+    }
+  } catch (error) {
+    console.error(error)
+    return {
+      success: false,
+      data: null,
+      error: '네트워크 오류가 발생했습니다.',
+    }
+  }
+}

--- a/libs/api/dashboard/getDashboardMembers.ts
+++ b/libs/api/dashboard/getDashboardMembers.ts
@@ -1,0 +1,61 @@
+'use server'
+
+import { cookies } from 'next/headers'
+import { ApiResult } from '@/libs/types/Api'
+import { GetMembersResponse } from '@/libs/types/Dashboard'
+
+interface GetMembersParams {
+  dashboardId: number
+  page?: number
+  size?: number
+}
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL
+
+export const getDashboardMembers = async ({
+  dashboardId,
+  page = 1,
+  size = 20,
+}: GetMembersParams): Promise<ApiResult<GetMembersResponse>> => {
+  try {
+    const cookieStore = await cookies()
+    const token = cookieStore.get('accessToken')?.value
+
+    const params = new URLSearchParams({
+      dashboardId: dashboardId.toString(),
+      page: page.toString(),
+      size: size.toString(),
+    })
+
+    const response = await fetch(`${BASE_URL}/members?${params.toString()}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    })
+
+    const result = await response.json()
+
+    if (!response.ok) {
+      return {
+        success: false,
+        data: null,
+        error: result.message || '멤버 목록을 불러오지 못했습니다.',
+      }
+    }
+
+    return {
+      success: true,
+      data: result,
+      error: null,
+    }
+  } catch (error) {
+    console.error(error)
+    return {
+      success: false,
+      data: null,
+      error: '네트워크 오류가 발생했습니다.',
+    }
+  }
+}

--- a/libs/api/dashboard/getDeashboardDetail.ts
+++ b/libs/api/dashboard/getDeashboardDetail.ts
@@ -1,0 +1,47 @@
+'use server'
+
+import { cookies } from 'next/headers'
+import { ApiResult } from '@/libs/types/Api'
+import { Dashboard } from '@/libs/types/Dashboard'
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL
+
+export const getDashboardDetail = async (
+  dashboardId: number,
+): Promise<ApiResult<Dashboard>> => {
+  try {
+    const cookieStore = await cookies()
+    const token = cookieStore.get('accessToken')?.value
+
+    const response = await fetch(`${BASE_URL}/dashboards/${dashboardId}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    })
+
+    const result = await response.json()
+
+    if (!response.ok) {
+      return {
+        success: false,
+        data: null,
+        error: result.message || '대시보드 정보를 가져오지 못했습니다.',
+      }
+    }
+
+    return {
+      success: true,
+      data: result,
+      error: null,
+    }
+  } catch (error) {
+    console.error(error)
+    return {
+      success: false,
+      data: null,
+      error: '네트워크 연결 상태를 확인해주세요.',
+    }
+  }
+}

--- a/libs/api/dashboard/updateDashboard.ts
+++ b/libs/api/dashboard/updateDashboard.ts
@@ -1,0 +1,69 @@
+'use server'
+
+import { cookies } from 'next/headers'
+import { ApiResult } from '@/libs/types/Api'
+import { Dashboard } from '@/libs/types/Dashboard'
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL
+
+const COLOR_MAP: Record<string, string> = {
+  red: '#AE2E24',
+  orange: '#9F4B00',
+  yellow: '#9E7600',
+  green: '#206E4E',
+  blue: '#1458BC',
+}
+
+export const updateDashboard = async (
+  dashboardId: number,
+  formData: FormData,
+): Promise<ApiResult<Dashboard>> => {
+  try {
+    const cookieStore = await cookies()
+    const token = cookieStore.get('accessToken')?.value
+
+    const title = formData.get('title') as string
+    const rawColor = formData.get('color') as string
+    const color = COLOR_MAP[rawColor.toLowerCase()] || rawColor
+
+    if (!title || !color) {
+      return {
+        success: false,
+        data: null,
+        error: '제목과 색상을 모두 입력해주세요.',
+      }
+    }
+
+    const response = await fetch(`${BASE_URL}/dashboards/${dashboardId}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ title, color }),
+    })
+
+    const result = await response.json()
+
+    if (!response.ok) {
+      return {
+        success: false,
+        data: null,
+        error: result.message || '대시보드 수정에 실패했습니다.',
+      }
+    }
+
+    return {
+      success: true,
+      data: result,
+      error: null,
+    }
+  } catch (error) {
+    console.error(error)
+    return {
+      success: false,
+      data: null,
+      error: '네트워크 오류가 발생했습니다.',
+    }
+  }
+}

--- a/libs/types/Dashboard.ts
+++ b/libs/types/Dashboard.ts
@@ -49,3 +49,19 @@ export interface GetInvitationsResponse {
   totalCount: number
   invitations: Invitation[]
 }
+
+export interface Member {
+  id: number
+  userId: number
+  email: string
+  nickname: string
+  profileImageUrl: string | null
+  createdAt: string
+  updatedAt: string
+  isOwner: boolean
+}
+
+export interface GetMembersResponse {
+  members: Member[]
+  totalCount: number
+}


### PR DESCRIPTION
### 📝작업 내용
#84 

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- [ ]  대시보드 이름 및 색상 GET -> Dashboards [GET] 대시보드 상세 조회
- [ ]  대시보드 이름 및 색상 PUT -> Dashboard [PUT] 대시보드 수정
- [ ]  대시보드 구성원 GET -> Members [GET] 대시보드 멤버 목록 조회
- [ ]  대시보드 구성원 DELETE -> Members [DELETE] 대시보드 멤버 삭제


### 💬리뷰 요구사항(선택)

대시보드 수정 api 연결까지 보너스
현서님 프리티어 작동하는지 확인 필요합니다
