### PR TITLE
feat: 대시보드 헤더

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,5 +1,6 @@
 import SideMenu from '@/components/dashboard/SideMenu'
 import Header from '@/components/dashboard/Header'
+import DashboardMobileDimm from '@/components/dashboard/DashboardMobileDimm'
 
 export default function DashboardLayout({
   children,
@@ -9,6 +10,7 @@ export default function DashboardLayout({
   return (
     <div className="flex h-screen overflow-hidden">
       <SideMenu />
+      <DashboardMobileDimm />
       <div className="flex flex-1 flex-col overflow-x-hidden overflow-y-auto">
         <Header />
         <main className="flex-1">{children}</main>

--- a/components/dashboard/DashboardHeaderMemberList.tsx
+++ b/components/dashboard/DashboardHeaderMemberList.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Image from 'next/image'
+import { getDashboardMembers } from '@/libs/api/dashboard/getDashboardMembers'
+import DefaultProfileImg from '@/assets/imgs/img_default_profile.svg'
+import type { Member } from '@/libs/types/Dashboard'
+
+interface DashboardHeaderMemberListProps {
+  dashboardId: number
+}
+
+export default function DashboardHeaderMemberList({
+  dashboardId,
+}: DashboardHeaderMemberListProps) {
+  const [members, setMembers] = useState<Member[]>([])
+
+  useEffect(() => {
+    let isCancelled = false
+
+    const fetch = async () => {
+      const res = await getDashboardMembers({ dashboardId, size: 6 })
+      if (isCancelled) return
+
+      if (res.success && res.data) {
+        setMembers(res.data.members)
+      }
+    }
+
+    fetch()
+    return () => {
+      isCancelled = true
+    }
+  }, [dashboardId])
+
+  return (
+    <div className="flex items-center text-white">
+      {members.map((member) => (
+        <div
+          key={member.id}
+          className="relative -ml-4 flex h-8 w-8 items-center justify-center overflow-hidden rounded-full bg-white"
+        >
+          {member.profileImageUrl ? (
+            <Image
+              src={member.profileImageUrl}
+              alt={`${member.nickname ?? 'member'} profile`}
+              fill
+              sizes="32px"
+              className="object-cover"
+              unoptimized
+            />
+          ) : (
+            <DefaultProfileImg className="absolute inset-0 h-full w-full text-black" />
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/components/dashboard/DashboardMobileDimm.tsx
+++ b/components/dashboard/DashboardMobileDimm.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+export default function DashboardMobileDimm() {
+  const handleClose = () => {
+    document
+      .querySelectorAll('.sidebar')
+      .forEach((el) => el.classList.add('hidden'))
+  }
+
+  return (
+    <div
+      onClick={handleClose}
+      className="sidebar fixed inset-0 z-40 hidden bg-black/70 md:hidden"
+    />
+  )
+}

--- a/components/dashboard/Header.tsx
+++ b/components/dashboard/Header.tsx
@@ -1,12 +1,14 @@
 'use client'
 
-import { ElementType } from 'react'
+import { ElementType, useEffect, useState } from 'react'
 import Link from 'next/link'
 import Setting from '@/assets/icons/ic_setting.svg'
 import UserPlus from '@/assets/icons/ic_user_plus.svg'
 import Logout from '@/assets/icons/ic_logout.svg'
 import InviteMemberModal from './edit/InviteMemberModal'
 import useDashboardHeader from '@/libs/hooks/useDashboardHeader'
+import DashboardHeaderMemberList from './DashboardHeaderMemberList'
+import { getDashboardDetail } from '@/libs/api/dashboard/getDeashboardDetail'
 
 const BUTTON_STYLE =
   'hover:bg-modal active:bg-black-300 flex items-center gap-2 rounded-xs px-3 py-2.5 cursor-pointer text-gray-400 text-lg-16-medium transition-colors'
@@ -53,9 +55,34 @@ export default function Header() {
     handleLogout,
   } = useDashboardHeader()
 
+  const [isCreatedMyDashboard, setIsCreatedMyDashboard] = useState(false)
+
+  useEffect(() => {
+    let ignore = false
+
+    const fetchDetail = async () => {
+      const res = await getDashboardDetail(Number(dashboardId))
+
+      if (ignore) return
+
+      if (res.data) {
+        setIsCreatedMyDashboard(res.data.createdByMe)
+      }
+    }
+
+    fetchDetail()
+
+    return () => {
+      ignore = true
+    }
+  }, [dashboardId])
+
   return (
     <header className="bg-bg border-black-300 flex h-18 w-full items-center justify-end border-b-2 p-7.5">
       <nav className="flex gap-4">
+        {!isMyDashboard && (
+          <DashboardHeaderMemberList dashboardId={Number(dashboardId)} />
+        )}
         {isMyDashboard && (
           <HeaderActionButton
             onClick={handleLogout}
@@ -64,7 +91,7 @@ export default function Header() {
           />
         )}
 
-        {!isMyDashboard && (
+        {!isMyDashboard && isCreatedMyDashboard && (
           <>
             <HeaderActionButton
               href={`/dashboard/${dashboardId}/edit`}

--- a/components/dashboard/Header.tsx
+++ b/components/dashboard/Header.tsx
@@ -9,6 +9,7 @@ import InviteMemberModal from './edit/InviteMemberModal'
 import useDashboardHeader from '@/libs/hooks/useDashboardHeader'
 import DashboardHeaderMemberList from './DashboardHeaderMemberList'
 import { getDashboardDetail } from '@/libs/api/dashboard/getDeashboardDetail'
+import MobileSideMenuButton from '@/assets/icons/ic_sidemenu.svg'
 
 const BUTTON_STYLE =
   'hover:bg-modal active:bg-black-300 flex items-center gap-2 rounded-xs px-3 py-2.5 cursor-pointer text-gray-400 text-lg-16-medium transition-colors'
@@ -18,16 +19,18 @@ const HeaderActionButton = ({
   href,
   icon: Icon,
   label,
+  isLogout,
 }: {
   onClick?: () => void
   href?: string
   icon: ElementType
   label: string
+  isLogout?: boolean
 }) => {
   const content = (
     <>
       <Icon aria-label={`${label} 아이콘`} />
-      {label}
+      <span className={`${!isLogout && `hidden md:block`}`}>{label}</span>
     </>
   )
 
@@ -41,6 +44,23 @@ const HeaderActionButton = ({
   return (
     <button onClick={onClick} className={BUTTON_STYLE}>
       {content}
+    </button>
+  )
+}
+
+const DashboardMobileButton = () => {
+  const handleSideMenuClick = () => {
+    const sidebars = document.querySelectorAll('.sidebar')
+
+    sidebars.forEach((el) => {
+      el.classList.toggle('hidden')
+      el.classList.add('flex')
+    })
+  }
+
+  return (
+    <button onClick={handleSideMenuClick} className="text-gray-300 md:hidden">
+      <MobileSideMenuButton />
     </button>
   )
 }
@@ -60,6 +80,13 @@ export default function Header() {
   useEffect(() => {
     let ignore = false
 
+    const sidebars = document.querySelectorAll('.sidebar')
+
+    sidebars.forEach((el) => {
+      el.classList.toggle('hidden')
+      el.classList.add('flex')
+    })
+
     const fetchDetail = async () => {
       const res = await getDashboardDetail(Number(dashboardId))
 
@@ -78,7 +105,8 @@ export default function Header() {
   }, [dashboardId])
 
   return (
-    <header className="bg-bg border-black-300 flex h-18 w-full items-center justify-end border-b-2 p-7.5">
+    <header className="bg-bg border-black-300 flex h-18 w-full items-center justify-between border-b-2 p-7.5 md:justify-end">
+      <DashboardMobileButton />
       <nav className="flex gap-4">
         {!isMyDashboard && (
           <DashboardHeaderMemberList dashboardId={Number(dashboardId)} />
@@ -88,6 +116,7 @@ export default function Header() {
             onClick={handleLogout}
             icon={Logout}
             label="로그아웃"
+            isLogout
           />
         )}
 

--- a/components/dashboard/Header.tsx
+++ b/components/dashboard/Header.tsx
@@ -83,8 +83,7 @@ export default function Header() {
     const sidebars = document.querySelectorAll('.sidebar')
 
     sidebars.forEach((el) => {
-      el.classList.toggle('hidden')
-      el.classList.add('flex')
+      el.classList.add('hidden')
     })
 
     const fetchDetail = async () => {

--- a/components/dashboard/SideMenu.tsx
+++ b/components/dashboard/SideMenu.tsx
@@ -13,7 +13,7 @@ export default async function SideMenu() {
   const dashboards = result.success && result.data ? result.data.dashboards : []
 
   return (
-    <aside className="bg-black-500 flex h-full w-[300px] shrink-0 flex-col border-r border-gray-900 py-2">
+    <aside className="bg-black-500 sidebar absolute z-50 hidden h-full w-[300px] shrink-0 flex-col border-r border-gray-900 py-2 md:static md:flex">
       <SidebarHeader />
       <SidebarDashboardList dashboards={dashboards} />
       <div className="mt-auto">

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,16 @@
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'sprint-fe-project.s3.ap-northeast-2.amazonaws.com',
+        port: '',
+        pathname: '/**',
+      },
+    ],
+  },
   turbopack: {
     rules: {
       '*.svg': {


### PR DESCRIPTION
### 📝작업 내용
#99 

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 대시보드 멤버 아바타
- 본인 대시보드 아니면 관리, 초대 버튼 안 보이게
- 외부 이미지 사용에 필요한 nextjs config 추가
- 모바일 사이드메뉴 토글 버튼 추가

### 💬리뷰 요구사항(선택)
- 현서님 ProfileEditModal 작업하실 때 제가 img 대신 Image 태그 얘기를 해서 바꾸셨었는데 
이게 width 프롭이 없어서 프로필 편집에 사진 추가하면 에러가 나오더라구요? 혹시 수정했다가 컨플릭트 나면 먼가 참사가 날 수도 잇을 것 같아서 일단 냅둿습니다.

- 프로필 수정 컴포넌트와 대시보드 헤더가 떨어져 있기 때문에 자신의 프로필 아바타를 변경 시 대시보드 멤버 목록이 표시되는 헤더에도 바로 반영하기가 쉽지 않더라구요. 
이 문제를 해결하려면 contextApi를 도입하거나 강제 새로고침을 하는 방법이 있습니다.
고민을 매우 많이 해봤는데요, 좀 짜치긴 하지만 강제 새로고침이 정신 건강에는 이로울듯 합니다.
